### PR TITLE
docker-entrypoint.sh can now edit flink-conf.yaml even if it was already edited

### DIFF
--- a/biggis-docker/biggis-pipeline/biggis-flink/docker-entrypoint.sh
+++ b/biggis-docker/biggis-pipeline/biggis-flink/docker-entrypoint.sh
@@ -20,7 +20,7 @@
 
 if [ "$1" = "jobmanager" ]; then
     echo "Starting Job Manager"
-    sed -i -e "s/jobmanager.rpc.address: localhost/jobmanager.rpc.address: `hostname -i`/g" $FLINK_HOME/conf/flink-conf.yaml
+    sed -i -e "s/jobmanager.rpc.address: .*/jobmanager.rpc.address: `hostname -i`/g" $FLINK_HOME/conf/flink-conf.yaml
     sed -i -e "s/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: `grep -c ^processor /proc/cpuinfo`/g" $FLINK_HOME/conf/flink-conf.yaml
     echo "config file: " && grep '^[^\n#]' $FLINK_HOME/conf/flink-conf.yaml
     $FLINK_HOME/bin/jobmanager.sh start cluster


### PR DESCRIPTION
Without this patch biggis-flink fails on repeated restarts if the docker instance gets a different IP address than on first start. This can e.g. happen if the docker host is rebooted.

This patch fixes this problem by replacing any value for jobmanager.rpc.address with the current IP address, not just "localhost".